### PR TITLE
Add Author and Address entities

### DIFF
--- a/quarkus-base-project/src/main/java/org/example/Address.java
+++ b/quarkus-base-project/src/main/java/org/example/Address.java
@@ -1,0 +1,11 @@
+package org.example;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+
+@Entity
+public class Address extends PanacheEntity {
+    public String street;
+    public String city;
+    public String country;
+}

--- a/quarkus-base-project/src/main/java/org/example/AddressResource.java
+++ b/quarkus-base-project/src/main/java/org/example/AddressResource.java
@@ -1,0 +1,47 @@
+package org.example;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+
+@Path("/addresses")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class AddressResource {
+
+    @GET
+    public Uni<List<Address>> list() {
+        return Address.listAll();
+    }
+
+    @GET
+    @Path("{id}")
+    public Uni<Address> get(@PathParam("id") Long id) {
+        return Address.findById(id);
+    }
+
+    @POST
+    public Uni<Address> add(Address address) {
+        return address.persist().replaceWith(address);
+    }
+
+    @PUT
+    @Path("{id}")
+    public Uni<Address> update(@PathParam("id") Long id, Address addressData) {
+        return Address.<Address>findById(id)
+                .invoke(entity -> {
+                    if (entity != null) {
+                        entity.street = addressData.street;
+                        entity.city = addressData.city;
+                        entity.country = addressData.country;
+                    }
+                });
+    }
+
+    @DELETE
+    @Path("{id}")
+    public Uni<Boolean> delete(@PathParam("id") Long id) {
+        return Address.deleteById(id);
+    }
+}

--- a/quarkus-base-project/src/main/java/org/example/Author.java
+++ b/quarkus-base-project/src/main/java/org/example/Author.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import io.quarkus.hibernate.reactive.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.OneToOne;
+
+@Entity
+public class Author extends PanacheEntity {
+    public String name;
+
+    @OneToOne
+    public Address address;
+}

--- a/quarkus-base-project/src/main/java/org/example/AuthorResource.java
+++ b/quarkus-base-project/src/main/java/org/example/AuthorResource.java
@@ -1,0 +1,46 @@
+package org.example;
+
+import io.smallrye.mutiny.Uni;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import java.util.List;
+
+@Path("/authors")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class AuthorResource {
+
+    @GET
+    public Uni<List<Author>> list() {
+        return Author.listAll();
+    }
+
+    @GET
+    @Path("{id}")
+    public Uni<Author> get(@PathParam("id") Long id) {
+        return Author.findById(id);
+    }
+
+    @POST
+    public Uni<Author> add(Author author) {
+        return author.persist().replaceWith(author);
+    }
+
+    @PUT
+    @Path("{id}")
+    public Uni<Author> update(@PathParam("id") Long id, Author authorData) {
+        return Author.<Author>findById(id)
+                .invoke(entity -> {
+                    if (entity != null) {
+                        entity.name = authorData.name;
+                        entity.address = authorData.address;
+                    }
+                });
+    }
+
+    @DELETE
+    @Path("{id}")
+    public Uni<Boolean> delete(@PathParam("id") Long id) {
+        return Author.deleteById(id);
+    }
+}

--- a/quarkus-base-project/src/main/java/org/example/Book.java
+++ b/quarkus-base-project/src/main/java/org/example/Book.java
@@ -2,9 +2,14 @@ package org.example;
 
 import io.quarkus.hibernate.reactive.panache.PanacheEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.ManyToOne;
+
+import org.example.Author;
 
 @Entity
 public class Book extends PanacheEntity {
     public String title;
-    public String author;
+
+    @ManyToOne
+    public Author author;
 }

--- a/quarkus-base-project/src/test/java/org/example/AddressResourceTest.java
+++ b/quarkus-base-project/src/test/java/org/example/AddressResourceTest.java
@@ -1,0 +1,17 @@
+package org.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class AddressResourceTest {
+
+    @Test
+    public void testListAddressesEndpoint() {
+        RestAssured.get("/addresses").then()
+                .statusCode(200)
+                .body(CoreMatchers.is("[]"));
+    }
+}

--- a/quarkus-base-project/src/test/java/org/example/AuthorResourceTest.java
+++ b/quarkus-base-project/src/test/java/org/example/AuthorResourceTest.java
@@ -1,0 +1,17 @@
+package org.example;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class AuthorResourceTest {
+
+    @Test
+    public void testListAuthorsEndpoint() {
+        RestAssured.get("/authors").then()
+                .statusCode(200)
+                .body(CoreMatchers.is("[]"));
+    }
+}


### PR DESCRIPTION
## Summary
- create `Author` and `Address` entities
- connect `Book` to the new `Author` entity
- expose REST resources for authors and addresses
- add small tests for the new resources

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68417a6b736c8330a0a31b899f92d219